### PR TITLE
Convert deb822 parsing into something that streams

### DIFF
--- a/jq/deb822.jq
+++ b/jq/deb822.jq
@@ -1,5 +1,71 @@
 # https://manpages.debian.org/testing/dpkg-dev/deb822.5.en.html
 
+# given a stream of deb822-formatted input lines, this outputs a stream of parsed objects (like "deb822_parse" below, but in streaming form)
+#
+#   jq --raw-input --null-input 'include "deb822"; deb822_stream(inputs) | ...'
+#
+def deb822_stream(lines):
+	foreach (
+		lines,
+		"" # inject a synthetic blank line at the end of the input stream to make sure we output everything (because we only output on empty lines, when we know an "entry" is done)
+		| select(
+			# ignore comment lines (optional in the spec, but for documents that should not have them they are invalid syntax anyhow so should be fairly harmless to strip unilaterally)
+			startswith("#")
+			| not
+		)
+	) as $line ({ accum: {}, out: {}, cur: "" };
+		if $line == "" then
+			.out = .accum
+			| .accum = {}
+			| .cur = ""
+		else # TODO should we throw an error if a line contains a newline? (that's bad input)
+			($line | sub("^[ \t]+"; "")) as $ltrim
+			| ($ltrim | sub("[ \t]+$"; "")) as $trim
+			| if $ltrim != $line then
+				# TODO what to do here if .cur is empty?? 🫠
+				.accum[.cur] += "\n" + $trim
+			else
+				(
+					$trim
+					| capture("^(?<key>[^:]+?):[ \t]*(?<value>.*)$")
+				) as $parsed
+				| if $parsed then
+					.cur = $parsed.key
+					| .accum[.cur] = $parsed.value
+				else . end # ignore malformed lines that miss a colon
+			end
+			| .out = {}
+		end
+		;
+		.out
+		| if length > 0 then
+			.
+		else empty end
+	)
+;
+
+# given a set of potentially inline-signed PGP lines, this strips the "PGP noise" (and assumes nothing exists outside it -- this is NOT signature verification by any stretch of the imagination!)
+def filter_inline_pgp_noise(lines):
+	foreach lines as $line ({ out: null, stripHash: false, sig: false };
+		if .sig then
+			.out = null
+			| if $line == "-----END PGP SIGNATURE-----" then
+				.sig = false
+			else . end
+		elif .stripHash and ($line | startswith("Hash:")) then
+			.out = null
+		elif .stripHash and $line == "" then
+			. *= { out: null, stripHash: false }
+		elif $line == "-----BEGIN PGP SIGNED MESSAGE-----" then
+			. *= { out: null, stripHash: true }
+		elif $line == "-----BEGIN PGP SIGNATURE-----" then
+			. *= { out: null, sig: true }
+		else
+			.out = $line
+		end
+	; if .out then .out else empty end)
+;
+
 # input:
 #   Foo: bar
 #   Bar: baz
@@ -26,41 +92,13 @@
 #     }
 #   ]
 def deb822_parse:
-	# normalize CRLF to just LF
-	gsub("\r\n|\r"; "\n")
-
-	# naïve PGP stripping
-	| gsub("^-----BEGIN PGP SIGNED MESSAGE-----\nHash: [^\n]+\n+|\n+-----BEGIN PGP SIGNATURE-----\n.*\n-----END PGP SIGNATURE-----\n*$"; ""; "m")
-
-	# strip any comments (optional in the spec, but for documents that should not have them they are invalid syntax anyhow so should be harmless to strip)
-	| gsub("(^|\n)(#[^\n]*($|\n))+"; "\n")
-
-	# strip any leading/trailing newlines
-	| gsub("^\n+|\n+$"; "")
-
-	# split on double newlines
-	| split("\n\n+"; "")
-	# now we have an array of "paragraphs"
-
-	| map(
-		# ignore extra blanks (usually completely empty file)
-		select(. != "")
-
-		# split on newlines that are not followed by space or tab
-		| split("\n(?![ \t])"; "")
-		# now we have an array of "fields"
-
-		| map(
-			index(":") as $colon
-			| select($colon) # ignore malformed lines that miss a colon
-			| { (.[0:$colon]): (
-				.[$colon+1:]
-				| gsub("^[ \t]+|[ \t]+$"; "")
-				| gsub("[ \t]*\n[ \t]*"; "\n")
-			) }
+	[
+		deb822_stream(
+			filter_inline_pgp_noise(
+				split("\n")[]
+			)
 		)
-		| add
-	)
+	]
 ;
 
 # TODO convert the above output back into deb822


### PR DESCRIPTION
This makes it work *way* more efficiently for large datasets, especially if they can be parsed/filtered incrementally.

For a timing comparison, parsing all of http://deb.debian.org/debian/dists/trixie/main/binary-amd64/Packages.xz with the old code took ~4 hours and the new code takes ~30 seconds (even if we load it all into memory just like the old code did).

Special thanks to @jcarter3 for the inadvertent/indirect nerd snipe and @jonjohnsonjr and @paultag for the added moral support.